### PR TITLE
doc: fix examples for radarr_root_folder module

### DIFF
--- a/plugins/modules/radarr_root_folder.py
+++ b/plugins/modules/radarr_root_folder.py
@@ -34,12 +34,12 @@ EXAMPLES = r'''
 ---
 # Create a root folder
 - name: Create a root folder
-  devopsarr.radarr.root_folder:
+  devopsarr.radarr.radarr_root_folder:
     path: '/series'
 
 # Delete a root folder
 - name: Delete a root_folder
-  devopsarr.radarr.root_folder:
+  devopsarr.radarr.radarr_root_folder:
     path: '/series'
     state: absent
 '''


### PR DESCRIPTION
The documentation available at https://galaxy.ansible.com/ui/repo/published/devopsarr/radarr/content/module/radarr_root_folder/ includes examples that do not work due to the wrong fully qualified name of the module.